### PR TITLE
fix: add market-quote tool with crypto snapshot support

### DIFF
--- a/src/providers/alpaca/market-data.ts
+++ b/src/providers/alpaca/market-data.ts
@@ -196,6 +196,20 @@ export class AlpacaMarketDataProvider implements MarketDataProvider {
     return parseSnapshot(symbol, snapshot);
   }
 
+  async getCryptoSnapshot(symbol: string): Promise<Snapshot> {
+    const response = await this.client.dataRequest<{ snapshots: AlpacaSnapshotsResponse }>(
+      "GET",
+      "/v1beta3/crypto/us/snapshots",
+      { symbols: symbol }
+    );
+
+    const snapshot = response.snapshots?.[symbol as keyof typeof response.snapshots];
+    if (!snapshot) {
+      throw new Error(`No crypto snapshot data for ${symbol}`);
+    }
+    return parseSnapshot(symbol, snapshot);
+  }
+
   async getSnapshots(symbols: string[]): Promise<Record<string, Snapshot>> {
     const response = await this.client.dataRequest<AlpacaSnapshotsResponse>(
       "GET",


### PR DESCRIPTION
## Summary

- **Added `market-quote` MCP tool** — The agent (`agent-v1.mjs`) calls `market-quote` to get crypto price data, but this tool was never registered on the MCP server, causing `quote_error` for every crypto symbol (BTC/USD, ETH/USD, SOL/USD) on every polling cycle.
- **Added `getCryptoSnapshot()` to the Alpaca market data provider** — The existing market data methods all hit `/v2/stocks/` endpoints, which don't serve crypto data. Alpaca serves crypto snapshots from `/v1beta3/crypto/us/snapshots`. The new method hits the correct endpoint and returns the same `Snapshot` type, so it's compatible with the rest of the codebase.
- **Auto-detects crypto vs stock symbols** — The `market-quote` tool checks for `/` in the symbol (e.g. `BTC/USD`) to route to the crypto endpoint, while stock symbols use the existing `getSnapshot()` path.

## Problem

Every 30 seconds the agent logs:
```
[Crypto] quote_error (BTC/USD)
[Crypto] quote_error (ETH/USD)
[Crypto] quote_error (SOL/USD)
```

Root cause: `CryptoAgent.getQuote()` calls `this.callTool("market-quote", { symbol })` but no tool named `market-quote` exists in `registerMarketDataTools()`. The call throws, gets caught, and returns null — so crypto signals are never generated.

## Changes

| File | Change |
|------|--------|
| `src/providers/alpaca/market-data.ts` | Added `getCryptoSnapshot()` method using `/v1beta3/crypto/us/snapshots` |
| `src/mcp/agent.ts` | Registered `market-quote` tool, added it to `catalog-list` |

## Test plan

- [ ] Deploy and verify `quote_error` logs are gone for crypto symbols
- [ ] Confirm crypto momentum signals appear in dashboard
- [ ] Verify stock symbols still work through `market-quote` (e.g. `AAPL`)
- [ ] Confirm `catalog-list` includes `market-quote` in Market Data category

🤖 Generated with [Claude Code](https://claude.com/claude-code)