### PR TITLE
fix: use getCryptoSnapshot for crypto symbols in researchSignal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ coverage/
 *.bak
 *.tmp
 *.temp
+.claude

--- a/src/durable-objects/mahoraga-harness.ts
+++ b/src/durable-objects/mahoraga-harness.ts
@@ -1443,8 +1443,16 @@ JSON response:
 
     try {
       const alpaca = createAlpacaProviders(this.env);
-      const quote = await alpaca.marketData.getQuote(symbol).catch(() => null);
-      const price = quote?.ask_price || quote?.bid_price || 0;
+      const isCrypto = symbol.includes("/");
+      let price = 0;
+
+      if (isCrypto) {
+        const snapshot = await alpaca.marketData.getCryptoSnapshot(symbol).catch(() => null);
+        price = snapshot?.latest_trade?.price || 0;
+      } else {
+        const quote = await alpaca.marketData.getQuote(symbol).catch(() => null);
+        price = quote?.ask_price || quote?.bid_price || 0;
+      }
 
       const prompt = `Should we BUY this stock based on social sentiment and fundamentals?
 


### PR DESCRIPTION
researchSignal() was using getQuote() for all symbols causing crypto symbols to return null, 
causing price to default to $0 in LLM research prompts; "Price is $0. indicating potential issues with the asset".

Now routes crypto symbols (containing "/") to getCryptoSnapshot().