### PR TITLE
fix: prevent settings modal inputs from resetting during status polling

### DIFF
--- a/dashboard/src/components/SettingsModal.tsx
+++ b/dashboard/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import type { Config } from '../types'
 import { Panel } from './Panel'
 
@@ -12,10 +12,6 @@ export function SettingsModal({ config, onSave, onClose }: SettingsModalProps) {
   const [localConfig, setLocalConfig] = useState<Config>(config)
   const [saving, setSaving] = useState(false)
   const [apiToken, setApiToken] = useState(localStorage.getItem('mahoraga_api_token') || '')
-
-  useEffect(() => {
-    setLocalConfig(config)
-  }, [config])
 
   const handleTokenSave = () => {
     if (apiToken) {


### PR DESCRIPTION
## Summary

Config inputs in the settings modal were being reset every 5 seconds, making it impossible to type values. This was caused by a `useEffect` syncing `localConfig` with the `config` prop whenever status polling updated.

## Changes

- Removed unnecessary `useEffect` that synced `localConfig` with `config` on every change
- Initial `useState(config)` is sufficient since the modal remounts when opened

## Test Plan

- [x] Open settings modal and type in any input field
- [x] Confirm values persist through multiple 5-second status polling cycles
- [x] Confirm closing and reopening the modal loads fresh config values