### PR TITLE
feat: add OPENAI_BASE_URL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ LLM_MODEL=gpt-4o-mini
 
 # --- Option 1: OpenAI Direct (openai-raw) ---
 # Get your key at: https://platform.openai.com/api-keys
+# Optional: override OpenAI API base URL (useful for OpenAI-compatible proxies)
+# OPENAI_BASE_URL=https://api.openai.com/v1
+# OPENAI_BASE_URL=https://openrouter.ai/api/v1
 OPENAI_API_KEY=sk-your_openai_api_key_here
 
 # --- Option 2: AI SDK (ai-sdk) ---

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npx wrangler secret put LLM_MODEL     # e.g. "gpt-4o-mini" or "anthropic/claude-
 
 # LLM API Keys (based on provider mode)
 npx wrangler secret put OPENAI_API_KEY         # For openai-raw or ai-sdk with OpenAI
+npx wrangler secret put OPENAI_BASE_URL        # Optional: override OpenAI base URL for openai-raw and ai-sdk (OpenAI models)
 # npx wrangler secret put ANTHROPIC_API_KEY    # For ai-sdk with Anthropic
 # npx wrangler secret put GOOGLE_GENERATIVE_AI_API_KEY  # For ai-sdk with Google
 # npx wrangler secret put XAI_API_KEY          # For ai-sdk with xAI/Grok
@@ -180,6 +181,10 @@ MAHORAGA supports multiple LLM providers via three modes:
 | `openai-raw` | Direct OpenAI API (default) | `OPENAI_API_KEY` |
 | `ai-sdk` | Vercel AI SDK with 5 providers | One or more provider keys |
 | `cloudflare-gateway` | Cloudflare AI Gateway (/compat) | `CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID`, `CLOUDFLARE_AI_GATEWAY_ID`, `CLOUDFLARE_AI_GATEWAY_TOKEN` |
+
+**Optional OpenAI Base URL Override:**
+
+- `OPENAI_BASE_URL` — Override the base URL used for OpenAI requests. Applies to `LLM_PROVIDER=openai-raw` and OpenAI models in `LLM_PROVIDER=ai-sdk` (models starting with `openai/`). Default: `https://api.openai.com/v1`.
 
 **Cloudflare AI Gateway Notes:**
 

--- a/dashboard/src/components/SettingsModal.tsx
+++ b/dashboard/src/components/SettingsModal.tsx
@@ -215,7 +215,7 @@ export function SettingsModal({ config, onSave, onClose }: SettingsModalProps) {
                 </select>
                 <p className="text-[9px] text-hud-text-dim mt-1">
                   {localConfig.llm_provider === 'ai-sdk' && 'Supports: OpenAI, Anthropic, Google, xAI, DeepSeek'}
-                  {(!localConfig.llm_provider || localConfig.llm_provider === 'openai-raw') && 'Uses OPENAI_API_KEY directly.'}
+                  {(!localConfig.llm_provider || localConfig.llm_provider === 'openai-raw') && 'Uses OPENAI_API_KEY directly (+ optional OPENAI_BASE_URL).'}
                   {localConfig.llm_provider &&
                     !['openai-raw', 'ai-sdk', 'cloudflare-gateway'].includes(localConfig.llm_provider) &&
                     'Provider is configured in the backend; selection is hidden in the dashboard.'}

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -206,6 +206,11 @@
         <td>Your OpenAI API key</td>
       </tr>
       <tr>
+        <td><code>OPENAI_BASE_URL</code></td>
+        <td>No</td>
+        <td>Optional OpenAI base URL override (e.g., OpenAI-compatible proxy). Default: <code>https://api.openai.com/v1</code></td>
+      </tr>
+      <tr>
         <td><code>KILL_SWITCH_SECRET</code></td>
         <td>Yes</td>
         <td>Secret for HMAC signing tokens</td>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -127,6 +127,7 @@ cd dashboard && npm install && cd ..</pre>
 ALPACA_API_SECRET=your_alpaca_secret
 ALPACA_PAPER=true
 OPENAI_API_KEY=your_openai_key
+OPENAI_BASE_URL=https://api.openai.com/v1  # optional (OpenAI-compatible proxy)
 MAHORAGA_API_TOKEN=generate_a_secure_random_token
 KILL_SWITCH_SECRET=another_secure_random_token</pre>
 

--- a/docs/harness.html
+++ b/docs/harness.html
@@ -144,6 +144,7 @@
     <pre>npx wrangler secret put ALPACA_API_KEY
 npx wrangler secret put ALPACA_API_SECRET
 npx wrangler secret put OPENAI_API_KEY
+npx wrangler secret put OPENAI_BASE_URL        # Optional (OpenAI-compatible proxy)
 npx wrangler secret put KILL_SWITCH_SECRET
 
 # Optional

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -9,6 +9,7 @@ export interface Env {
   ALPACA_API_SECRET: string;
   ALPACA_PAPER?: string;
   OPENAI_API_KEY?: string;
+  OPENAI_BASE_URL?: string;
   ANTHROPIC_API_KEY?: string;
   GOOGLE_GENERATIVE_AI_API_KEY?: string;
   XAI_API_KEY?: string;

--- a/src/providers/llm/ai-sdk.ts
+++ b/src/providers/llm/ai-sdk.ts
@@ -36,6 +36,8 @@ export interface AISDKConfig {
   model: string;
   /** API keys for each provider */
   apiKeys: Partial<Record<SupportedProvider, string>>;
+  /** Optional OpenAI base URL override (e.g., OpenAI-compatible proxy). */
+  openaiBaseUrl?: string;
 }
 
 type ProviderFactory =
@@ -60,7 +62,12 @@ export class AISDKProvider implements LLMProvider {
 
     // Initialize providers based on available API keys
     if (config.apiKeys.openai) {
-      this.providers.openai = createOpenAI({ apiKey: config.apiKeys.openai });
+      const rawBaseUrl = config.openaiBaseUrl?.trim().replace(/\/+$/, "");
+      const openaiOptions: { apiKey: string; baseURL?: string } = { apiKey: config.apiKeys.openai };
+      if (rawBaseUrl) {
+        openaiOptions.baseURL = rawBaseUrl;
+      }
+      this.providers.openai = createOpenAI(openaiOptions);
     }
     if (config.apiKeys.anthropic) {
       this.providers.anthropic = createAnthropic({ apiKey: config.apiKeys.anthropic });

--- a/src/providers/llm/factory.test.ts
+++ b/src/providers/llm/factory.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Env } from "../../env.d";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("createLLMProvider", () => {
+  it("openai-raw uses OPENAI_BASE_URL for request URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "test",
+        choices: [{ message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+      }),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { createLLMProvider } = await import("./factory");
+    const env = {
+      OPENAI_API_KEY: "test",
+      OPENAI_BASE_URL: "https://example.com/v1/",
+      LLM_PROVIDER: "openai-raw",
+    } as unknown as Env;
+
+    const provider = createLLMProvider(env);
+    expect(provider).not.toBeNull();
+
+    await provider!.complete({
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/v1/chat/completions",
+      expect.any(Object)
+    );
+  });
+
+  it("ai-sdk passes OPENAI_BASE_URL to @ai-sdk/openai createOpenAI", async () => {
+    const createOpenAIMock = vi.fn(() => ((modelId: string) => ({ modelId })) as unknown as any);
+    const createAnthropicMock = vi.fn(() => ((modelId: string) => ({ modelId })) as unknown as any);
+    const createGoogleMock = vi.fn(() => ((modelId: string) => ({ modelId })) as unknown as any);
+    const createXaiMock = vi.fn(() => ((modelId: string) => ({ modelId })) as unknown as any);
+    const createDeepSeekMock = vi.fn(() => ((modelId: string) => ({ modelId })) as unknown as any);
+
+    vi.doMock("@ai-sdk/openai", () => ({ createOpenAI: createOpenAIMock }));
+    vi.doMock("@ai-sdk/anthropic", () => ({ createAnthropic: createAnthropicMock }));
+    vi.doMock("@ai-sdk/google", () => ({ createGoogleGenerativeAI: createGoogleMock }));
+    vi.doMock("@ai-sdk/xai", () => ({ createXai: createXaiMock }));
+    vi.doMock("@ai-sdk/deepseek", () => ({ createDeepSeek: createDeepSeekMock }));
+
+    const { createLLMProvider } = await import("./factory");
+
+    const env = {
+      OPENAI_API_KEY: "test",
+      OPENAI_BASE_URL: "https://proxy.example/v1/",
+      LLM_PROVIDER: "ai-sdk",
+      LLM_MODEL: "openai/gpt-4o-mini",
+    } as unknown as Env;
+
+    const provider = createLLMProvider(env);
+    expect(provider).not.toBeNull();
+
+    expect(createOpenAIMock).toHaveBeenCalledWith({
+      apiKey: "test",
+      baseURL: "https://proxy.example/v1",
+    });
+  });
+
+  it("ignores whitespace OPENAI_BASE_URL", async () => {
+    const createOpenAIMock = vi.fn(() => ((modelId: string) => ({ modelId })) as unknown as any);
+
+    vi.doMock("@ai-sdk/openai", () => ({ createOpenAI: createOpenAIMock }));
+
+    const { createLLMProvider } = await import("./factory");
+
+    const env = {
+      OPENAI_API_KEY: "test",
+      OPENAI_BASE_URL: "   ",
+      LLM_PROVIDER: "ai-sdk",
+      LLM_MODEL: "openai/gpt-4o-mini",
+    } as unknown as Env;
+
+    const provider = createLLMProvider(env);
+    expect(provider).not.toBeNull();
+
+    expect(createOpenAIMock).toHaveBeenCalledWith({
+      apiKey: "test",
+    });
+  });
+});
+

--- a/src/providers/llm/factory.ts
+++ b/src/providers/llm/factory.ts
@@ -20,6 +20,8 @@ export type LLMProviderType = "openai-raw" | "ai-sdk" | "cloudflare-gateway";
 export function createLLMProvider(env: Env): LLMProvider | null {
   const providerType = (env.LLM_PROVIDER as LLMProviderType) ?? "openai-raw";
   const model = env.LLM_MODEL ?? "gpt-4o-mini";
+  const openaiBaseUrlRaw = env.OPENAI_BASE_URL?.trim().replace(/\/+$/, "");
+  const openaiBaseUrl = openaiBaseUrlRaw ? openaiBaseUrlRaw : undefined;
 
   switch (providerType) {
     case "cloudflare-gateway": {
@@ -67,7 +69,7 @@ export function createLLMProvider(env: Env): LLMProvider | null {
         return null;
       }
 
-      return createAISDKProvider({ model, apiKeys });
+      return createAISDKProvider({ model, apiKeys, openaiBaseUrl });
     }
 
     case "openai-raw":
@@ -79,6 +81,7 @@ export function createLLMProvider(env: Env): LLMProvider | null {
       return createOpenAIProvider({
         apiKey: env.OPENAI_API_KEY,
         model: model.includes("/") ? model.split("/")[1] : model,
+        baseUrl: openaiBaseUrl,
       });
   }
 }

--- a/src/providers/llm/openai.ts
+++ b/src/providers/llm/openai.ts
@@ -31,7 +31,7 @@ export class OpenAIProvider implements LLMProvider {
   constructor(config: OpenAIConfig) {
     this.apiKey = config.apiKey;
     this.model = config.model ?? "gpt-4o-mini";
-    this.baseUrl = config.baseUrl ?? "https://api.openai.com/v1";
+    this.baseUrl = (config.baseUrl ?? "https://api.openai.com/v1").trim().replace(/\/+$/, "");
   }
 
   async complete(params: CompletionParams): Promise<CompletionResult> {

--- a/wrangler.example.jsonc
+++ b/wrangler.example.jsonc
@@ -30,6 +30,7 @@
 	//
 	// Provider API Keys (based on LLM_PROVIDER mode):
 	// - OPENAI_API_KEY (for openai-raw, or ai-sdk with OpenAI models)
+	// - OPENAI_BASE_URL (optional override for OpenAI-compatible proxy; affects openai-raw and ai-sdk OpenAI models)
 	// - ANTHROPIC_API_KEY (for ai-sdk with Anthropic models)
 	// - GOOGLE_GENERATIVE_AI_API_KEY (for ai-sdk with Google models)
 	// - XAI_API_KEY (for ai-sdk with xAI/Grok models)


### PR DESCRIPTION
Many LLMs provider are compatible with OpenAI API `chat/completions` endpoint. To change the client provider you can simply change the base_url from the default `https://api.openai.com/v1` to a custom one.