### PR TITLE
reschedule alarm if stale

### DIFF
--- a/src/durable-objects/mahoraga-harness.ts
+++ b/src/durable-objects/mahoraga-harness.ts
@@ -845,6 +845,16 @@ export class MahoragaHarness extends DurableObject<Env> {
         this.state = { ...DEFAULT_STATE, ...stored };
       }
       this.initializeLLM();
+
+      // Reschedule alarm if stale - in local dev, past alarms don't fire on restart;
+      // in production this is a defensive check for edge cases (long inactivity, redeployments)
+      if (this.state.enabled) {
+        const existingAlarm = await this.ctx.storage.getAlarm();
+        const now = Date.now();
+        if (!existingAlarm || existingAlarm < now) {
+          await this.ctx.storage.setAlarm(now + 5_000);
+        }
+      }
     });
   }
 


### PR DESCRIPTION
## Fix stale Durable Object alarm on restart                                                                                                                                                         
                                                               
  ### Problem                                                                                                                                                                                          
                                                                                                                                                                                                       
  When the agent is enabled and the worker restarts (common in local dev), the alarm loop stops running despite `enabled: true` being persisted in storage.                                            
                                                               
  **Root cause:** The alarm timestamp persists in DO storage, but if it's in the past (from a previous session), it won't fire. The constructor restored `enabled: true` but never checked if the alarm
   needed rescheduling.

  ### Fix

  Added a startup check in the DO constructor that reschedules the alarm if:
  - Agent is enabled AND
  - No alarm exists OR alarm is in the past

  ```typescript
  if (this.state.enabled) {
    const existingAlarm = await this.ctx.storage.getAlarm();
    const now = Date.now();
    if (!existingAlarm || existingAlarm < now) {
      await this.ctx.storage.setAlarm(now + 5_000);
    }
  }