### PR TITLE
remove unused mcp_url

### DIFF
--- a/agent-config.example.json
+++ b/agent-config.example.json
@@ -1,6 +1,4 @@
 {
-  "mcp_url": "http://localhost:8787/mcp",
-  
   "data_poll_interval_ms": 30000,
   "analyst_interval_ms": 120000,
   

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -51,7 +51,6 @@ export interface CostTracker {
 }
 
 export interface Config {
-  mcp_url: string
   data_poll_interval_ms: number
   analyst_interval_ms: number
   max_position_value: number


### PR DESCRIPTION
Was only used in these 2 files so far

```
❯ rg "mcp_url"
agent-config.example.json
2:  "mcp_url": "http://localhost:8787/mcp",

dashboard/src/types.ts
54:  mcp_url: string
```