### PR TITLE
PR2: aggregate social signals and fix staleness volume

### DIFF
--- a/src/durable-objects/mahoraga-harness.ts
+++ b/src/durable-objects/mahoraga-harness.ts
@@ -904,7 +904,6 @@ export class MahoragaHarness extends DurableObject<Env> {
 
       if (now - this.state.lastDataGatherRun >= this.state.config.data_poll_interval_ms) {
         await this.runDataGatherers();
-        this.state.lastDataGatherRun = now;
       }
 
       if (now - this.state.lastResearchRun >= RESEARCH_INTERVAL_MS) {
@@ -1288,6 +1287,7 @@ export class MahoragaHarness extends DurableObject<Env> {
       .slice(0, MAX_SIGNALS);
 
     this.state.signalCache = freshSignals;
+    this.state.lastDataGatherRun = now;
 
     this.log("System", "data_gathered", {
       stocktwits: stocktwitsSignals.length,
@@ -1334,14 +1334,11 @@ export class MahoragaHarness extends DurableObject<Env> {
   }
 
   private pruneSocialHistoryInPlace(history: SocialHistoryEntry[], cutoffMs: number): void {
-    let pruneCount = 0;
-    for (const entry of history) {
-      if (entry.timestamp >= cutoffMs) break;
-      pruneCount++;
-    }
-    if (pruneCount > 0) {
-      history.splice(0, pruneCount);
-    }
+    if (history.length === 0) return;
+
+    const pruned = history.filter((entry) => entry.timestamp >= cutoffMs);
+    pruned.sort((a, b) => a.timestamp - b.timestamp);
+    history.splice(0, history.length, ...pruned);
   }
 
   private updateSocialHistoryFromSnapshot(
@@ -1356,6 +1353,7 @@ export class MahoragaHarness extends DurableObject<Env> {
     for (const [symbol, s] of snapshot) {
       touchedSymbols.add(symbol);
       const history = this.state.socialHistory[symbol] ?? [];
+      if (history.length > 1) history.sort((a, b) => a.timestamp - b.timestamp);
       const last = history[history.length - 1];
 
       if (last && nowMs - last.timestamp < SOCIAL_HISTORY_BUCKET_MS) {
@@ -1393,7 +1391,7 @@ export class MahoragaHarness extends DurableObject<Env> {
   private getSocialSnapshotCache(): Record<string, SocialSnapshotCacheEntry> {
     // Prefer the snapshot captured during the most recent gather run. This represents the full gathered set
     // (age-filtered, uncapped), while `signalCache` is capped and sentiment-biased for research/LLM costs.
-    if (this.state.socialSnapshotCacheUpdatedAt >= this.state.lastDataGatherRun) {
+    if (this.state.socialSnapshotCacheUpdatedAt > 0) {
       return this.state.socialSnapshotCache;
     }
 


### PR DESCRIPTION
**Disclaimer: both code and description below is LLM generated**

# PR: Social staleness v2 (aggregated social volume) + state growth fixes

## Summary

This branch upgrades staleness detection and trade metadata by aggregating social signals per symbol (volume + sentiment + sources) and wiring that into:

- Stale-position exits (so “social volume decay” is based on real data)
- `positionEntries` (so entries record aggregated social sentiment/volume/sources)

It also adds guardrails to keep Durable Object persisted state bounded and to avoid false “0 social volume” reads when the signal cache is capped.

## The issues (vs `main`)

### 1) Staleness “social volume decay” was effectively always zero

On `main`, staleness checks called `analyzeStaleness(symbol, price, 0)`, meaning:

- `currentSocialVolume` was always `0`
- `volumeRatio = currentSocialVolume / entry_social_volume` tended toward `0`
- The “social volume decay” portion of the staleness score could be maxed out even when the symbol still had meaningful social activity

This can lead to premature stale exits and noisy staleness scoring.

### 2) Persisted state could grow without bound (introduced by the initial PR2 changes)

To support better staleness/social metrics, this branch introduced `socialHistory` (a 24h rolling time-series). The initial implementation only pruned history for symbols present in the latest snapshot; if tickers churn over time, old symbols would never be revisited/pruned, causing unbounded Durable Object state growth.

### 3) Using a capped/sentiment-biased cache for “current social volume” could be wrong (introduced by the initial PR2 changes)

`signalCache` is intentionally:

- Age-filtered
- Sorted by `abs(sentiment)`
- Capped to 200 signals

When there are many signals, a held/entry symbol can be filtered out of the top 200 even if it has non-trivial volume. Building the “current social volume” snapshot from `signalCache` can therefore incorrectly treat that symbol as having 0 volume, inflating staleness.

## What changed

### A) Aggregate social signals into a per-symbol snapshot

Added `buildSocialSnapshot(signals)` which aggregates:

- `volume` (sum)
- `sentiment` (volume-weighted average)
- `sources` (set of contributing source details)

This snapshot is used to drive staleness checks and to record entry metadata more accurately.

### B) Staleness now uses actual social volume (and entry records are improved)

- `runAnalyst()` now computes `currentSocialVolume` from the aggregated snapshot and passes it into `analyzeStaleness()`.
- When recording a new entry in `positionEntries`, we now prefer aggregated values:
  - `entry_sentiment`: aggregated (fallback to original signal / confidence)
  - `entry_social_volume`: aggregated (fallback to original signal)
  - `entry_sources`: aggregated sources (fallback to subreddit/source)

This improves both decisioning and post-trade explainability.

### C) Fix: prevent unbounded `socialHistory` growth

`updateSocialHistoryFromSnapshot()` now:

- Prunes old entries for symbols in the current snapshot
- Also prunes symbols missing from the snapshot
- Deletes keys when histories become empty

Result: persisted state stays bounded even with ticker churn.

### D) Fix: avoid using capped `signalCache` for staleness social volume

- `runDataGatherers()` now computes social metrics from the full age-filtered gathered signal set **before** sorting/slicing down to `signalCache`.
- Introduced a persisted `socialSnapshotCache` (plus timestamp) so analyst/premarket logic can reliably reference the uncapped per-symbol snapshot even though `signalCache` remains capped for cost/perf reasons.
- Added `getSocialSnapshotCache()` with a fallback for older persisted states.

Result: held/entry symbols won’t accidentally look like they have “0 social volume” just because they weren’t in the top-200 by abs(sentiment).

## Why this improves the trading app

- More accurate stale exits: the “social volume decay” score now reflects real observed volume, reducing false positives and unnecessary sells.
- More reliable behavior under heavy signal load: staleness and entry metadata use an uncapped snapshot, while `signalCache` can remain capped for LLM/research efficiency.
- Better auditability/analytics: `positionEntries` now captures aggregated social sentiment/volume and the contributing sources, making it easier to understand why a trade was entered and how momentum changed.
- Operational stability: bounded `socialHistory` prevents Durable Object state ballooning over long runtimes, improving reliability and reducing risk of storage-related issues.

## Testing

- `npm run typecheck`
- `npm run test:run`
- `npm run check`

