### PR TITLE
Fix market hours calculation to use Eastern Time for accurate trading…

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -257,7 +257,7 @@ export default function App() {
     })
   }, [portfolioHistory, portfolioPeriod])
 
-  const { marketMarkers, marketHoursZone } = useMemo(() => {
+const { marketMarkers, marketHoursZone } = useMemo(() => {
     if (portfolioPeriod !== '1D' || portfolioHistory.length === 0) {
       return { marketMarkers: undefined, marketHoursZone: undefined }
     }
@@ -268,8 +268,18 @@ export default function App() {
     
     portfolioHistory.forEach((s, i) => {
       const date = new Date(s.timestamp)
-      const hours = date.getHours()
-      const minutes = date.getMinutes()
+      
+      // Get time in Eastern Time (where US markets operate)
+      const formatter = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'America/New_York',
+        hour: 'numeric',
+        minute: 'numeric',
+        hour12: false
+      })
+      
+      const parts = formatter.formatToParts(date)
+      const hours = parseInt(parts.find(p => p.type === 'hour')?.value || '0', 10)
+      const minutes = parseInt(parts.find(p => p.type === 'minute')?.value || '0', 10)
       
       if (hours === 9 && minutes >= 30 && minutes < 45 && openIndex === -1) {
         openIndex = i


### PR DESCRIPTION
Fix market open/close markers to use Eastern Time

Market hour markers (open at 9:30 AM, close at 4:00 PM) were using the user's local timezone instead of Eastern Time where US markets actually operate. This caused markers to appear at incorrect times for users outside of ET.

Now uses `Intl.DateTimeFormat` with `America/New_York` timezone to correctly identify market hours regardless of user location. Also handles EST/EDT transitions automatically.

Note: The alpaca clock PR didn't fix the markers for me at least, added `Intl.DateTimeFormat` again but with cleaner diff